### PR TITLE
Add instruction about Nuxt v2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,18 @@
 
 - Add `@nuxtjs/guess` dependency using yarn or npm to your project
 - Add `@nuxtjs/guess` to modules section of `nuxt.config.js`
+- If using Nuxt > 2.4.0, set `router.prefetchLinks` to `false` in `nuxt.config.js`
 
 ```javascript
-{
+ {
   modules: [
     [ '@nuxtjs/guess', { GA: 'XXXXXXX' }]
- ]
-}
+   ]
+ },
+ // Nuxt > 2.4.0
+ router: {
+    prefetchLinks: false
+ }
 ```
 
 Options given directly to [guess-webpack options](https://www.npmjs.com/package/guess-webpack#advanced-usage).


### PR DESCRIPTION
According to Atinux's comment https://github.com/nuxt/nuxt.js/pull/4574#issuecomment-450194516, the "native" prefetch  feature of Nuxt needs to be disabled for Guess.js to work. So I thought it would good to update the Readme accordingly.